### PR TITLE
fix: восстановить состояние при повреждении state.json

### DIFF
--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -26,3 +26,14 @@ def test_state_store_updates_and_respects_dry_run(tmp_path):
     store.update_last_seen(message_id=7, dry_run=False)
     saved = store.read()
     assert saved.last_seen_id == 7
+
+
+def test_state_store_recovers_from_corrupted_file(tmp_path):
+    path = tmp_path / "state.json"
+    path.write_text("not-a-json", encoding="utf-8")
+    store = StateStore(path)
+
+    state = store.read()
+
+    assert state.last_seen_id == 0
+    assert path.read_text(encoding="utf-8") == "{\"last_seen_id\":0}"


### PR DESCRIPTION
## Summary
- восстанавливать `state.json`, если его содержимое не удаётся распарсить или содержит некорректный `last_seen_id`
- добавить тест, подтверждающий корректное восстановление повреждённого файла состояния

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2c1be30c08330a167516b4be3016b