### PR TITLE
fix: синхронизировать секреты с переменными окружения

### DIFF
--- a/.github/workflows/twitter-poster.yml
+++ b/.github/workflows/twitter-poster.yml
@@ -15,10 +15,13 @@ jobs:
       TELETHON_API_ID: ${{ secrets.TELETHON_API_ID }}
       TELETHON_API_HASH: ${{ secrets.TELETHON_API_HASH }}
       TELETHON_SESSION: ${{ secrets.TELETHON_SESSION }}
-      TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
-      TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
-      TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-      TWITTER_ACCESS_SECRET: ${{ secrets.TWITTER_ACCESS_SECRET }}
+      API_ID: ${{ secrets.TELETHON_API_ID || secrets.API_ID }}
+      API_HASH: ${{ secrets.TELETHON_API_HASH || secrets.API_HASH }}
+      STRING_SESSION: ${{ secrets.TELETHON_SESSION || secrets.STRING_SESSION }}
+      TELEGRAMCANALISTOCHNIK: ${{ secrets.TELEGRAMCANALISTOCHNIK || vars.TELEGRAMCANALISTOCHNIK || '@binance_announcements' }}
+      TWITTER_CLIENT_ID: ${{ secrets.TWITTER_CLIENT_ID || secrets.TWITTER_API_KEY }}
+      TWITTER_REFRESH_TOKEN: ${{ secrets.TWITTER_REFRESH_TOKEN || secrets.TWITTER_ACCESS_TOKEN }}
+      TWITTER_REDIRECT_URI: ${{ secrets.TWITTER_REDIRECT_URI || vars.TWITTER_REDIRECT_URI || 'https://localhost' }}
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
       DRY_RUN: ${{ vars.DRY_RUN || 'false' }}
     steps:
@@ -32,7 +35,8 @@ jobs:
         run: |
           set -euo pipefail
           for var in TELETHON_API_ID TELETHON_API_HASH TELETHON_SESSION \
-            TWITTER_API_KEY TWITTER_API_SECRET TWITTER_ACCESS_TOKEN TWITTER_ACCESS_SECRET \
+            API_ID API_HASH STRING_SESSION TELEGRAMCANALISTOCHNIK \
+            TWITTER_CLIENT_ID TWITTER_REFRESH_TOKEN TWITTER_REDIRECT_URI \
             DEEPSEEK_API_KEY; do
             value="${!var-}"
             if [ -n "$value" ]; then
@@ -44,14 +48,30 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          declare -A required_groups=(
+            [API_ID]="API_ID TELETHON_API_ID"
+            [API_HASH]="API_HASH TELETHON_API_HASH"
+            [STRING_SESSION]="STRING_SESSION TELETHON_SESSION"
+            [TELEGRAMCANALISTOCHNIK]="TELEGRAMCANALISTOCHNIK"
+            [TWITTER_CLIENT_ID]="TWITTER_CLIENT_ID TWITTER_API_KEY"
+            [TWITTER_REFRESH_TOKEN]="TWITTER_REFRESH_TOKEN TWITTER_ACCESS_TOKEN"
+            [DEEPSEEK_API_KEY]="DEEPSEEK_API_KEY"
+          )
+
           missing=()
-          for var in TELETHON_API_ID TELETHON_API_HASH TELETHON_SESSION \
-            TWITTER_API_KEY TWITTER_API_SECRET TWITTER_ACCESS_TOKEN TWITTER_ACCESS_SECRET \
-            DEEPSEEK_API_KEY; do
-            if [ -z "${!var-}" ]; then
-              missing+=("$var")
+          for key in "${!required_groups[@]}"; do
+            found=false
+            for candidate in ${required_groups[$key]}; do
+              if [ -n "${!candidate-}" ]; then
+                found=true
+                break
+              fi
+            done
+            if [ "$found" = false ]; then
+              missing+=("${required_groups[$key]// /|}")
             fi
           done
+
           if [ "${#missing[@]}" -ne 0 ]; then
             echo "Отсутствуют переменные окружения: ${missing[*]}" >&2
             exit 1

--- a/src/telegram_source.py
+++ b/src/telegram_source.py
@@ -33,9 +33,9 @@ class TelegramSource:
     """Источник сообщений из Telegram-канала Binance."""
 
     def __init__(self, *, timeout: float = 10.0, fetch_limit: int = 50) -> None:
-        self.api_id = int(_get_env("API_ID"))
-        self.api_hash = _get_env("API_HASH")
-        self.string_session = _get_env("STRING_SESSION")
+        self.api_id = int(_get_env("API_ID", aliases=("TELETHON_API_ID",)))
+        self.api_hash = _get_env("API_HASH", aliases=("TELETHON_API_HASH",))
+        self.string_session = _get_env("STRING_SESSION", aliases=("TELETHON_SESSION",))
         self.channel = _get_env("TELEGRAMCANALISTOCHNIK")
         self.timeout = timeout
         self.fetch_limit = fetch_limit
@@ -111,10 +111,13 @@ class TelegramSource:
             await client.disconnect()
 
 
-def _get_env(name: str) -> str:
-    """Возвращает обязательную переменную окружения."""
+def _get_env(name: str, *, aliases: tuple[str, ...] = ()) -> str:
+    """Возвращает обязательную переменную окружения с учётом синонимов."""
 
-    value = os.getenv(name)
-    if not value:
-        raise RuntimeError(f"Не задана переменная окружения {name}")
-    return value
+    for candidate in (name, *aliases):
+        value = os.getenv(candidate)
+        if value:
+            return value
+
+    names = " | ".join((name, *aliases))
+    raise RuntimeError(f"Не задана переменная окружения из списка: {names}")


### PR DESCRIPTION
## Summary
- пробросил GitHub Secrets в переменные окружения, которые ожидает рантайм, и расширил валидацию в workflow
- добавил поддержку синонимов переменных окружения в клиентах Telegram и Twitter, чтобы Secrets и локальные .env совпадали
- сохранил текущую логику ретраев, обновив только подготовительный слой

## Testing
- pytest -q

## Impact
- производительность и сетевые запросы не изменились
- затронуты .github/workflows/twitter-poster.yml, src/telegram_source.py, src/twitter_client.py
- обработка ошибок и ретраи остались прежними, проверка переменных стала дружелюбнее


------
https://chatgpt.com/codex/tasks/task_e_68e2c7ea7c508330a059b7170d49d442