### PR TITLE
fix: корректное выполнение workflow без токенов Twitter

### DIFF
--- a/.github/workflows/twitter-poster.yml
+++ b/.github/workflows/twitter-poster.yml
@@ -30,6 +30,17 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure dry-run mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          normalized="${DRY_RUN:-false}"
+          if [ -z "${TWITTER_CLIENT_ID:-}" ] || [ -z "${TWITTER_REFRESH_TOKEN:-}" ]; then
+            echo "::notice::Учётные данные Twitter отсутствуют, включаю dry-run"
+            normalized="true"
+          fi
+          echo "DRY_RUN=${normalized}" >> "$GITHUB_ENV"
+
       - name: Mask secrets
         shell: bash
         run: |
@@ -48,6 +59,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          is_dry_run="${DRY_RUN,,}"
           declare -A required_groups=(
             [API_ID]="API_ID TELETHON_API_ID"
             [API_HASH]="API_HASH TELETHON_API_HASH"
@@ -60,6 +72,11 @@ jobs:
 
           missing=()
           for key in "${!required_groups[@]}"; do
+            if [ "$is_dry_run" = "true" ]; then
+              if [ "$key" = "TWITTER_CLIENT_ID" ] || [ "$key" = "TWITTER_REFRESH_TOKEN" ]; then
+                continue
+              fi
+            fi
             found=false
             for candidate in ${required_groups[$key]}; do
               if [ -n "${!candidate-}" ]; then

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 from pathlib import Path
 
 from .deepseek_client import DeepSeekClient
@@ -45,14 +46,29 @@ async def run(*, dry_run: bool) -> None:
             )
 
 
+def _env_dry_run_default() -> bool:
+    """Возвращает значение режима dry-run из переменной окружения."""
+
+    value = os.getenv("DRY_RUN", "false").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Публикация новостей Binance в Twitter"
     )
+    parser.set_defaults(dry_run=_env_dry_run_default())
     parser.add_argument(
         "--dry-run",
+        dest="dry_run",
         action="store_true",
         help="Не отправлять твиты и не сохранять состояние",
+    )
+    parser.add_argument(
+        "--no-dry-run",
+        dest="dry_run",
+        action="store_false",
+        help="Игнорировать переменную окружения DRY_RUN и публиковать твиты",
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## Изменения
- добавил автоматическое включение dry-run в GitHub Actions при отсутствии Twitter-токенов и ослабил проверку обязательных переменных в этом режиме
- позволил задавать режим dry-run через переменную окружения DRY_RUN и добавил флаг для явного отключения
- сделал TwitterClient толерантным к отсутствию токенов в dry-run режиме

## Влияние на сеть и производительность
- без изменений: при отсутствии токенов публикации не выполняются, запросы к API Twitter не отправляются

## Затронутые модули
- .github/workflows/twitter-poster.yml
- src/main.py
- src/twitter_client.py

## Ретраи и обработка ошибок
- логика ретраев не изменялась; добавлена только ранняя проверка режима dry-run

------
https://chatgpt.com/codex/tasks/task_e_68e2ca7355388330a1d99486d2b39717