### PR TITLE
fix: скорректировать импорт RPCError для Telethon

### DIFF
--- a/src/telegram_source.py
+++ b/src/telegram_source.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass
 
 from telethon import TelegramClient
-from telethon.errors import FloodWaitError, RpcError
+from telethon.errors import FloodWaitError, RPCError
 from telethon.sessions import StringSession
 from tenacity import (
     AsyncRetrying,
@@ -52,7 +52,7 @@ class TelegramSource:
                 wait=wait_exponential(multiplier=1, min=1, max=60),
                 stop=stop_after_attempt(5),
                 retry=retry_if_exception_type(
-                    (FloodWaitError, RpcError, asyncio.TimeoutError)
+                    (FloodWaitError, RPCError, asyncio.TimeoutError)
                 ),
                 reraise=True,
             ):


### PR DESCRIPTION
## Цель изменения
- Исправить падение приложения при запуске из-за изменившегося имени базового исключения в Telethon 1.41.

## Влияние на производительность и сеть
- Не изменяет сетевую активность и производительность: обновлён только список перехватываемых исключений.

## Затронутые модули
- `src/telegram_source.py`

## Ретраи и обработка ошибок
- Ретрай-логика остаётся прежней, но теперь корректно перехватывает `RPCError` из Telethon.

## Тестирование
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e2cce293b483308476f08b0e2af605